### PR TITLE
[KAFKA-8820] Code cleanup in the ReassignPartitionsCommand.

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -132,7 +132,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // reassign partition 0
     val oldAssignedReplicas = zkClient.getReplicasForPartition(new TopicPartition(topic, 0))
     val newReplicas = Seq(1, 2, 3)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None,
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None,
       Map(topicPartition -> newReplicas),  adminZkClient = adminZkClient)
     assertTrue("Partition reassignment should fail for [test,0]", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -493,7 +493,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     )
 
     //When we run a throttled reassignment
-    new ReassignPartitionsCommand(zkClient, None, move, adminZkClient = adminZkClient).reassignPartitions(throttle)
+    ReassignPartitionsCommand(zkClient, None, move, adminZkClient = adminZkClient).reassignPartitions(throttle)
 
     waitForZkReassignmentToComplete()
 
@@ -533,7 +533,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2) //increase replication factor
     )
 
-    new ReassignPartitionsCommand(zkClient, None, firstMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, firstMove, adminZkClient = adminZkClient).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -558,7 +558,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
       new TopicPartition("deliveries", 0) -> Seq(1, 2, 3) //increase replication factor
     )
 
-    new ReassignPartitionsCommand(zkClient, None, secondMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, secondMove, adminZkClient = adminZkClient).reassignPartitions()
     // Low pause to detect deletion of the reassign_partitions znode before the reassignment is complete
     waitForZkReassignmentToComplete(pause = 1L)
 
@@ -580,14 +580,14 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
 
     val thirdMove = Map(new TopicPartition("orders", 0) -> Seq(1, 2, 3))
 
-    new ReassignPartitionsCommand(zkClient, None, thirdMove, adminZkClient = adminZkClient).reassignPartitions()
+    ReassignPartitionsCommand(zkClient, None, thirdMove, adminZkClient = adminZkClient).reassignPartitions()
 
     val fourthMove = Map(new TopicPartition("payments", 1) -> Seq(2, 3))
 
     // Continuously attempt to set the reassignment znode with `fourthMove` until it succeeds. It will only succeed
     // after `thirdMove` completes.
     Iterator.continually {
-      try new ReassignPartitionsCommand(zkClient, None, fourthMove, adminZkClient = adminZkClient).reassignPartitions()
+      try ReassignPartitionsCommand(zkClient, None, fourthMove, adminZkClient = adminZkClient).reassignPartitions()
       catch {
         case _: AdminCommandFailedException => false
       }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -571,7 +571,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
                    brokers: Seq[Int] = Seq[Int]()): KafkaZkClient = {
     val zkClient: KafkaZkClient = createMock(classOf[KafkaZkClient])
     expect(zkClient.getReplicaAssignmentForTopics(anyObject().asInstanceOf[Set[String]])).andStubReturn(existingAssignment)
-    expect(zkClient.getAllBrokersInCluster).andStubReturn(brokers.map(TestUtils.createBroker(_, "", 1)))
+    expect(zkClient.getSortedBrokerList).andStubReturn(brokers.sorted)
     replay(zkClient)
     zkClient
   }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -52,7 +52,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindMovingReplicas(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given partition 0 moves from broker 100 -> 102. Partition 1 does not move.
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), control)
@@ -74,7 +74,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindMovingReplicasWhenProposedIsSubsetOfExisting(): Unit = {
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given we have more existing partitions than we are proposing
     val existingSuperset = Map(
@@ -110,7 +110,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindMovingReplicasMultiplePartitions(): Unit = {
     val control = new TopicPartition("topic1", 2) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given partitions 0 & 1 moves from broker 100 -> 102. Partition 2 does not move.
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), new TopicPartition("topic1", 1) -> Seq(100, 101), control)
@@ -135,7 +135,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindMovingReplicasMultipleTopics(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given topics 1 -> move from broker 100 -> 102, topics 2 -> move from broker 101 -> 100
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), new TopicPartition("topic2", 0) -> Seq(101, 102), control)
@@ -166,7 +166,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
 
   @Test
   def shouldFindMovingReplicasMultipleTopicsAndPartitions(): Unit = {
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given
     val existing = Map(
@@ -210,7 +210,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldFindTwoMovingReplicasInSamePartition(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
 
     //Given partition 0 has 2 moves from broker 102 -> 104 & 103 -> 105
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101, 102, 103), control)
@@ -236,7 +236,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   @Test
   def shouldNotOverwriteEntityConfigsWhenUpdatingThrottledReplicas(): Unit = {
     val control = new TopicPartition("topic1", 1) -> Seq(100, 102)
-    val assigner = new ReassignPartitionsCommand(null, null, null, null, null)
+    val assigner = ReassignPartitionsCommand(null, null, null, null, null)
     val existing = Map(new TopicPartition("topic1", 0) -> Seq(100, 101), control)
     val proposed = Map(new TopicPartition("topic1", 0) -> Seq(101, 102), control)
 
@@ -272,7 +272,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = new ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
+    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
     expect(admin.fetchEntityConfig(anyString(), anyString())).andStubReturn(new Properties)
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
     replay(admin)
@@ -298,7 +298,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = new ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
+    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
 
     //Expect the existing broker config to be changed from 10/100 to 1000
@@ -332,7 +332,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val zk = stubZKClient(existing)
     val admin: AdminZkClient = createMock(classOf[AdminZkClient])
     val propsCapture: Capture[Properties] = newCapture(CaptureType.ALL)
-    val assigner = new ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
+    val assigner = ReassignPartitionsCommand(zk, None, proposed, Map.empty, admin)
     expect(admin.changeBrokerConfig(anyObject().asInstanceOf[List[Int]], capture(propsCapture))).anyTimes()
 
     //Given there is some existing config
@@ -437,7 +437,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(0, 2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     assertTrue("Partition reassignment attempt failed for [test, 0]", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -466,7 +466,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(1, 2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     assertTrue("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -494,7 +494,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas),  adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas),  adminZkClient = adminZkClient)
     assertTrue("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
@@ -519,7 +519,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(2, 3)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     assertFalse("Partition reassignment failed for test, 0", reassignPartitionsCommand.reassignPartitions())
     val reassignedPartitions = zkClient.getPartitionReassignment
     assertFalse("Partition should not be reassigned", reassignedPartitions.contains(topicAndPartition))
@@ -536,7 +536,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
     val newReplicas = Seq(0, 1)
     val partitionToBeReassigned = 0
     val topicAndPartition = new TopicPartition(topic, partitionToBeReassigned)
-    val reassignPartitionsCommand = new ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
+    val reassignPartitionsCommand = ReassignPartitionsCommand(zkClient, None, Map(topicAndPartition -> newReplicas), adminZkClient = adminZkClient)
     reassignPartitionsCommand.reassignPartitions()
     // create brokers
     servers = TestUtils.createBrokerConfigs(2, zkConnect, false).map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))


### PR DESCRIPTION
Some small changes in the ReassignPartitionsCommand to make the KAFKA-8820 migration to supporting the AdminClient easier. 
In particular:
- switch from using getAllBrokersInCluster to using getSortedBrokerList since the data used is only that of the latter, and the former is implemented using the latter.
- Make the ReassignPartitionsCommand use a private constructor/companion object apply() method, which reduces the number of places for object entry.

It is recommended that you look at each commit individually for this PR.

This is not a final PR but one step on the way to KAFKA-8820.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
